### PR TITLE
Tag browsing and searching features

### DIFF
--- a/src/main/java/app/App.java
+++ b/src/main/java/app/App.java
@@ -6,6 +6,7 @@ import app.io.ConsoleIO;
 import app.io.IO;
 import app.ui.TextUI;
 import bookmarks.Bookmark;
+import java.util.ArrayList;
 
 import java.util.List;
 
@@ -42,11 +43,29 @@ public class App {
                 }
             } else if (command.equals("2") || command.equals("list")) {
                 String method = ui.askForListingMethod();
-                ui.printBookmarkList(dao.getBookmarksInOrder(method));
+                if(method.equals("LT")) {
+                    ui.presentTags(dao.getTagDAO().getTagsOnDatabase());
+                } else ui.printBookmarkList(dao.getBookmarksInOrder(method));
             } else if (command.equals("3") || command.equals("search")) {
                 String searchfield = ui.askForField();
-                String search = ui.askForSearch();
-                ui.printBookmarkList(dao.searchField(searchfield, search));
+                String search;
+                if(searchfield.equals("tag")) {
+                    List<Tag> tags = dao.getTagDAO().getTagsOnDatabase();
+                    ui.listTags(tags);
+                    search = ui.askForTag();
+                    boolean found = false;
+                    for (Tag tag : tags) {
+                        if(tag.getName().equals(search)) {
+                            ui.printBookmarkList(new ArrayList(tag.getBookmarks()));
+                            found = true;
+                            break;
+                        }
+                    }
+                    if(!found) ui.printTagsNotFound();
+                } else {
+                    search = ui.askForSearch();
+                    ui.printBookmarkList(dao.searchField(searchfield, search));
+                }
             } else if (command.equals("4") || command.equals("edit")) {
                 Long editID = ui.askForBookmarkToEdit(dao.getBookMarksOnDatabase());
                 String editfield = ui.askForEditField(dao.getSingleBookmarkInfo(editID));

--- a/src/main/java/app/dao/BookMarkDAO.java
+++ b/src/main/java/app/dao/BookMarkDAO.java
@@ -244,6 +244,10 @@ public class BookMarkDAO {
         return false;
     }
 
+    public TagDAO getTagDAO() {
+        return tagDAO;
+    }
+    
     private boolean databaseIsEmpty() {
         return getBookMarksOnDatabase().isEmpty();
     }

--- a/src/main/java/app/domain/Tag.java
+++ b/src/main/java/app/domain/Tag.java
@@ -23,11 +23,7 @@ public class Tag {
     Long id;
     
 
-//    @JoinTable(name = "tag_bookmarks",
-//            joinColumns = {
-//                @JoinColumn(name = "tag_id")},
-//            inverseJoinColumns = {
-//                @JoinColumn(name = "bookmark_id")})
+    
     @ManyToMany(mappedBy = "tags", fetch = FetchType.EAGER)
     @Fetch(value = FetchMode.SUBSELECT)
     private Set<Bookmark> bookmarks;

--- a/src/main/java/app/domain/Tag.java
+++ b/src/main/java/app/domain/Tag.java
@@ -4,10 +4,15 @@ import bookmarks.Bookmark;
 import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 @Entity
 public class Tag {
@@ -16,8 +21,15 @@ public class Tag {
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
+    
 
-    @ManyToMany(mappedBy = "tags")
+//    @JoinTable(name = "tag_bookmarks",
+//            joinColumns = {
+//                @JoinColumn(name = "tag_id")},
+//            inverseJoinColumns = {
+//                @JoinColumn(name = "bookmark_id")})
+    @ManyToMany(mappedBy = "tags", fetch = FetchType.EAGER)
+    @Fetch(value = FetchMode.SUBSELECT)
     private Set<Bookmark> bookmarks;
 
     @Column(name = "name", unique = true)
@@ -53,8 +65,8 @@ public class Tag {
         this.id = id;
     }
     
-    
 
+    
     @Override
     public String toString() {
         return this.name;

--- a/src/main/java/app/ui/TextUI.java
+++ b/src/main/java/app/ui/TextUI.java
@@ -38,9 +38,9 @@ public class TextUI {
         io.redPrint("Add");
         io.print(" a new bookmark \n2. ");
         io.redPrint("List");
-        io.print(" all existing bookmarks\n3. ");
+        io.print(" all existing bookmarks, or tags\n3. ");
         io.redPrint("Search");
-        io.print(" a specific bookmark\n4. ");
+        io.print(" for bookmarks\n4. ");
         io.redPrint("Edit");
         io.print(" a bookmark\n5. ");
         io.redPrint("Delete");
@@ -52,13 +52,15 @@ public class TextUI {
 
     public String askForField() {
         io.println("Which field would you like to search?");
-        io.println("Give field (T = Title) (D = Description)");
+        io.println("Give field (T = Title) (D = Description) (TA = Tag)");
         String command = io.nextLine();
         switch (command) {
             case ("T"):
                 return "title";
             case ("D"):
                 return "description";
+            case ("TA"):
+                return "tag";
             default:
                 return "";
         }
@@ -97,6 +99,7 @@ public class TextUI {
     public String askForListingMethod() {
         io.println("Choose listing method:");
         io.println("(T = Title)(CD = Creation time Descending)(CA = Creation time Ascending)");
+        io.println("(LT = List Tags)");
         return io.nextLine();
     }
 
@@ -109,6 +112,44 @@ public class TextUI {
             bmark.printInfo(io);
             io.println("==================================================");
         }
+    }
+    
+    public void presentTags(List<Tag> tags) {
+        io.println("");
+        io.println("Tags:");
+        io.println("----------------------------------------------");
+        if (tags.isEmpty()) {
+            io.println("No tags found.");
+        }
+        for (int i = 0; i < tags.size(); i++) {
+            Tag tag = tags.get(i);
+            Set<Bookmark> bmarks = tag.getBookmarks();
+            io.println("name: " + tag + "\n" + "bookmarks tagged:");
+            for (Bookmark bmark : bmarks) {
+                io.println(bmark.shortPrint());
+            }
+            io.println("Total amount of bookmarks tagged: " + bmarks.size());
+            io.println("==============================================");
+        }
+    }
+    
+    public void listTags(List<Tag> tags) {
+        io.println("");
+        io.println("Tags:");
+        io.println("");
+        for (Tag tag : tags) {
+            io.println(tag.toString());
+        }
+    }
+    
+    public String askForTag() {
+        io.println("");
+        io.println("Enter name of the tag to list bookmarks associated with it:");
+        return io.nextLine();
+    }
+    
+    public void printTagsNotFound() {
+        io.println("No tags with that title were found.");
     }
 
     private Bookmark askForOtherBookmarkInfo() {

--- a/src/test/resources/app/browse_tags.feature
+++ b/src/test/resources/app/browse_tags.feature
@@ -1,0 +1,11 @@
+Feature: Browsing for tags is possible
+    
+    Scenario: user can browse existing bookmarks
+        Given option "2" is selected
+        When input "LT" is entered
+        And app is created
+        Then system response will contain "cucumber"
+        And system response will contain "tutorial"
+        And system response will contain "podcast"
+        And system response will contain "deleted"
+        And system response will contain "antarctic"

--- a/src/test/resources/app/search_tags.feature
+++ b/src/test/resources/app/search_tags.feature
@@ -1,0 +1,31 @@
+Feature: Searching for bookmarks by tag is possible
+    
+    Scenario: User can find correct bookmarks with an existing tag
+        Given option "3" is selected
+        When input "TA" is entered
+        When input "podcast" is entered
+        And app is created
+        Then system response will contain "Antarctic weekly"
+        And system response will contain "Cucumber Experience"
+
+    Scenario: User searching with the tag option won't find tags with non existing tag names
+        Given option "3" is selected
+        When input "TA" is entered
+        When input "videos" is entered
+        And app is created
+        Then system response will contain "No tags with that title were found."
+        And system response will not contain "Cucumber Experience"
+        And system response will not contain "Cucumber tutorial"
+        And system response will not contain "DeleteCast"
+        And system response will not contain "Antarctic weekly"
+
+    Scenario: User searching with a tag will only find the bookmarks associated with that tag
+        Given option "3" is selected
+        When input "TA" is entered
+        When input "cucumber" is entered
+        And app is created
+        Then system response will not contain "DeleteCast"
+        And system response will not contain "Antarctic weekly"
+        And system response will contain "Cucumber Experience"
+        And system response will contain "Cucumber tutorial"
+

--- a/src/test/resources/app/tag_bookmark_counts.feature
+++ b/src/test/resources/app/tag_bookmark_counts.feature
@@ -1,0 +1,8 @@
+Feature: User can see the amount of bookmarks tagged with a particular tag
+    
+    Scenario: user can see the amount of bookmarks tagged with each existing tag.
+        Given option "2" is selected
+        When input "LT" is entered
+        And app is created
+        Then system response will contain "Total amount of bookmarks tagged: 2"
+        And system response will contain "Total amount of bookmarks tagged: 1"


### PR DESCRIPTION
Tag browsing and tag searching have been added. Tag browsing is listed as an option when Listing is selected. Searching bookmarks with a tag has also been added and it is listed as an option when Searching is selected.
This branch implements the 3 following feature stories:
-----------------------------------------------
As a User I want to browse tags
As a User I want to search by tags
As a User I want to see how many bookmarks are tagged with each tag
------------------------------------------------
I also made the tag listing option show short prints of the bookmarks associated with each tag
Searching with tags just shows the tags, before you can add a  tag as a search term.

I did some cucumber tests for each feature, and everything worked as far as
i could tell. Further testing(Unit testing or more cucumber scenarios) of course could be useful if someone feels inclined towards doing so.
